### PR TITLE
basic_example: set stationConf.bssid_set to 0

### DIFF
--- a/basic_example/user/user_main.c
+++ b/basic_example/user/user_main.c
@@ -30,6 +30,8 @@ user_init()
     //Set station mode
     wifi_set_opmode( 0x1 );
 
+    // Don't check the mac addr
+    stationConf.bssid_set = 0; 
     //Set ap settings
     os_memcpy(&stationConf.ssid, ssid, 32);
     os_memcpy(&stationConf.password, password, 64);


### PR DESCRIPTION
When bssid_set contains anything else than 0, it will only connect
to the ap if the mac address matches. If this is left uninitialized
it may contain garbage and the ESP will never connect to the ap.
