### PR TITLE
basic_example: set the baud rate to a standard value

### DIFF
--- a/basic_example/user/user_main.c
+++ b/basic_example/user/user_main.c
@@ -35,6 +35,9 @@ user_init()
     os_memcpy(&stationConf.password, password, 64);
     wifi_station_set_config(&stationConf);
 
+    // default appears to be a non-standard 74880 baud
+    uart_div_modify(0, UART_CLK_FREQ / 115200);
+
     //Start os task
     system_os_task(loop, user_procTaskPrio,user_procTaskQueue, user_procTaskQueueLen);
 


### PR DESCRIPTION
I'm using socat, and the man page said to do `socat -hh |grep ' b[1-9]'` to get all possible speeds, which is 30, none of them worked.  Other posts claim it is 74880 baud, instead set a standard computer value.  If nothing else this way the source code tells the user what to expect.
socat -,echo=0,icanon=0 /dev/ttyUSB0,raw,echo=0,b115200,crnl
